### PR TITLE
Fix example in the ScopeFromAttribute doc

### DIFF
--- a/modules/core/docs/authproc_scopefromattribute.md
+++ b/modules/core/docs/authproc_scopefromattribute.md
@@ -25,7 +25,7 @@ Set the `scope` attribute to the scope from the `eduPersonPrincipalName` attribu
     'authproc' => array(
         50 => array(
             'class' => 'core:ScopeFromAttribute',
-            'sourceAttribute' => 'eduPersonPrincipal'
-            'targetAttribute' => 'scope'
+            'sourceAttribute' => 'eduPersonPrincipalName',
+            'targetAttribute' => 'scope',
         ),
     ),


### PR DESCRIPTION
Change the source attribute to `eduPersonPrincipalName` and add missing commas.